### PR TITLE
Changed `pip3` to `python3 -m pip`

### DIFF
--- a/builders/vbox/rocky/packer/rocky_vbox.pkr.hcl
+++ b/builders/vbox/rocky/packer/rocky_vbox.pkr.hcl
@@ -66,7 +66,7 @@ build {
 
   provisioner "shell" {
     execute_command = "echo 'packer'|{{ .Vars }} sudo -S -E bash '{{ .Path }}'"
-    inline          = ["dnf -y update", "dnf -y install python3", "alternatives --set python /usr/bin/python3", "python3 -m pip install -U pip", "pip3 install ansible"]
+    inline          = ["dnf -y update", "dnf -y install python3", "alternatives --set python /usr/bin/python3", "python3 -m pip install -U pip", "python3 -m pip install ansible"]
   }
 
   #provisioner "ansible-local" {


### PR DESCRIPTION
Tested, still built with artifacts generated. Using `pip3` caused a warning in the build process.