### PR TITLE
Windows 10 build with Artifacts + Windows Update

### DIFF
--- a/builders/vbox/Windows 10/enable-winrm.ps1
+++ b/builders/vbox/Windows 10/enable-winrm.ps1
@@ -6,7 +6,7 @@ $ifaceinfo = Get-NetConnectionProfile
 Set-NetConnectionProfile -InterfaceIndex $ifaceinfo.InterfaceIndex -NetworkCategory Private 
 
 # Set up WinRM and configure some things
-winrm quickconfig -q
+Enable-PSRemoting -Force
 winrm s "winrm/config" '@{MaxTimeoutms="1800000"}'
 winrm s "winrm/config/winrs" '@{MaxMemoryPerShellMB="2048"}'
 winrm s "winrm/config/service" '@{AllowUnencrypted="true"}'

--- a/builders/vbox/Windows 10/packer/windows10_packer.pkr.hcl
+++ b/builders/vbox/Windows 10/packer/windows10_packer.pkr.hcl
@@ -49,6 +49,12 @@ source "virtualbox-iso" "vbox" {
 build {
   sources = ["source.virtualbox-iso.vbox"]
 
+  provisioner "powershell" {
+    elevated_user     = "SYSTEM"
+    elevated_password = ""
+    scripts           = ["update-windows.ps1"]
+  }
+
   provisioner "windows-restart" {
     restart_check_command = "powershell -command \"& {if ((get-content C:\\ProgramData\\lastboot.txt) -eq (Get-WmiObject win32_operatingsystem).LastBootUpTime) {Write-Output 'Sleeping for 600 seconds to wait for reboot'; start-sleep 600} else {Write-Output 'Reboot complete'}}\""
     restart_command       = "powershell \"& {(Get-WmiObject win32_operatingsystem).LastBootUpTime > C:\\ProgramData\\lastboot.txt; Restart-Computer -force}\""


### PR DESCRIPTION
Fixed the Windows Update step by executing in an elevated context. Windows seems to require explicitly escalating privileges when using remote tools such as WinRM and SSH. This is why executing the update script during the OOBE answer file pass worked but executing during the Packer build process didn't. OOBE executes locally, whereas the Packer powershell provisioner executes via WinRM.

To fix this, we made Packer execute the Windows Update script in an elevated context by assigning `elevated_user = "SYSTEM"` and `elevated_password =""` in the provisioner for just that script.